### PR TITLE
Confirm build/installation with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+jobs:
+  include: 
+    - os: linux
+      dist: bionic
+    - os: osx
+      osximage: xcode11.6
+language: cpp
+before_install:
+  - |
+    if [ "$TRAVIS_OS_NAME" =  "linux" ] 
+    then 
+      sudo apt-get update
+      sudo apt-get -y install dpkg-dev cmake g++ gcc binutils libx13-dev libxpm-dev libxft-dev libxext-dev python
+      wget https://root.cern/download/root_v6.22.00.Linux-ubuntu18-x86_64-gcc7.5.tar.gz
+      tar -xzf root_v6.22.00.Linux-ubuntu18-x86_64-gcc7.5.tar.gz
+    fi
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]
+    then
+      wget https://root.cern/download/root_v6.22.00.macosx64-10.15-clang110.tar.gz
+      tar -xzf root_v6.22.00.macosx64-10.15-clang110.tar.gz
+    fi
+  - export ROOTSH="$PWD/root/bin/thisroot.sh"
+script:
+  - source $ROOTSH 
+  - sh initialization.sh
+  - cd unfolding
+  - make
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
+language: cpp
 jobs:
   include: 
     - os: linux
       dist: bionic
     - os: osx
-      osximage: xcode11.6
-language: cpp
-before_install:
+      osx_image: xcode11.6
+install:
   - |
     if [ "$TRAVIS_OS_NAME" =  "linux" ] 
     then 


### PR DESCRIPTION
This pull request adds a `.travis.yml` file which follows the installation instructions and will check whether everything builds on linux and osx each time a new commit is made.
To take advantage of this, the repository will first have to be activated via https://travis-ci.com/ if not already done so.

As an example, [these are the build logs from my fork](https://www.travis-ci.com/github/notZaki/Neutron-Spectrometry/builds/176767945). 
It shows that the current code successfully builds on both linux and osx (yay!), but the [logs for the linux build](https://www.travis-ci.com/github/notZaki/Neutron-Spectrometry/jobs/363969612) did show a few warnings.

Pinging: @lgmontgomery 